### PR TITLE
Add Custom Error Handling Class for API Errors

### DIFF
--- a/apps/server/src/controllers/error.controller.js
+++ b/apps/server/src/controllers/error.controller.js
@@ -1,0 +1,37 @@
+import logger from '../lib/winston/index.js';
+
+/**
+ * Global error handling controller
+ */
+export default (err, req, res, next) => {
+  err.statusCode = err.statusCode || 500;
+  err.status = err.status || 'error';
+
+  const logMessage = `${err.statusCode} - ${err.message} - ${req.originalUrl} - ${req.method} - ${req.ip}`;
+
+  if (err.statusCode >= 500) {
+    logger.error(logMessage);
+    logger.error(err.stack);
+  } else if (err.statusCode >= 400) {
+    logger.warn(logMessage);
+  } else {
+    logger.info(logMessage);
+  }
+
+  if (process.env.NODE_ENV === 'production') {
+    res.status(err.statusCode).json({
+      status: err.status,
+      message:
+        err.statusCode >= 500
+          ? 'Something went wrong on the server'
+          : err.message,
+    });
+  } else {
+    res.status(err.statusCode).json({
+      status: err.status,
+      message: err.message,
+      stack: err.stack,
+      error: err,
+    });
+  }
+};

--- a/apps/server/src/middleware/errorHandler/index.js
+++ b/apps/server/src/middleware/errorHandler/index.js
@@ -1,0 +1,12 @@
+class AppError extends Error {
+  constructor(message, statusCode) {
+    super(message);
+
+    this.statusCode = statusCode;
+    this.status = `${statusCode}`.startsWith('4') ? 'fail' : 'error';
+    this.isOperational = true;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+export default AppError;


### PR DESCRIPTION

## Changes Made
- Added a custom `AppError` class for standardized error handling throughout the application
- This class extends the native Error class to include additional properties for API error handling:
  - `statusCode`: HTTP status code for the error response
  - `isOperational`: Flag to distinguish between operational vs programming errors
  - Custom stack trace handling

## Why
- Provides consistent error structure across the application
- Enables better error handling with appropriate HTTP status codes
- Separates operational errors (expected) from programming errors (unexpected)
- Improves debugging by preserving stack traces
